### PR TITLE
iOS does not have a apiversion 3.

### DIFF
--- a/iphone/manifest
+++ b/iphone/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: 1.4.1
-apiversion: 3
+apiversion: 2
 description: TiCollectionView
 author: Marcel Pociot
 license: MIT


### PR DESCRIPTION
Build error on Titianium SDK 6.0.0+

[ERROR] Found incompatible Titanium Modules:
[ERROR]    id: de.marcelpociot.collectionview	 version: 1.0	 platform: ios,iphone	 min sdk: 3.5.1.GA

Because, iOS does not have a apiversion 3.
https://jira.appcelerator.org/browse/TIMOB-24144